### PR TITLE
Closes #14: Add cyberpunk glitch effect on logo hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -101,3 +101,138 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Glitch effect for logo */
+.glitch-container {
+  position: relative;
+}
+
+.glitch-container::before,
+.glitch-container::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: inherit;
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.glitch-container:hover::before {
+  opacity: 0.8;
+  animation: glitch-rgb 0.3s steps(2) infinite;
+  background: var(--primary);
+  mix-blend-mode: multiply;
+}
+
+.glitch-container:hover::after {
+  opacity: 0.6;
+  animation: glitch-rgb 0.3s steps(2) infinite reverse;
+  background: oklch(0.7 0.2 330);
+  mix-blend-mode: screen;
+}
+
+.glitch-container:hover {
+  animation: glitch-jitter 0.3s steps(4) infinite;
+}
+
+.glitch-container:hover .glitch-icon {
+  animation: glitch-flicker 0.3s steps(3) infinite;
+}
+
+/* Scanline overlay */
+.glitch-container::before {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.1) 2px,
+    rgba(0, 0, 0, 0.1) 4px
+  );
+  background-size: 100% 4px;
+}
+
+.glitch-container:hover::before {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.15) 2px,
+    rgba(0, 0, 0, 0.15) 4px
+  );
+  opacity: 1;
+  animation: glitch-scanline 0.3s steps(2) infinite, glitch-rgb 0.3s steps(2) infinite;
+}
+
+@keyframes glitch-jitter {
+  0%, 100% {
+    transform: translate(0, 0);
+  }
+  25% {
+    transform: translate(-1px, 1px);
+  }
+  50% {
+    transform: translate(1px, -1px);
+  }
+  75% {
+    transform: translate(-1px, -1px);
+  }
+}
+
+@keyframes glitch-rgb {
+  0%, 100% {
+    clip-path: inset(0 0 85% 0);
+    transform: translate(-2px, 0);
+  }
+  25% {
+    clip-path: inset(15% 0 60% 0);
+    transform: translate(2px, 0);
+  }
+  50% {
+    clip-path: inset(40% 0 30% 0);
+    transform: translate(-1px, 0);
+  }
+  75% {
+    clip-path: inset(70% 0 10% 0);
+    transform: translate(1px, 0);
+  }
+}
+
+@keyframes glitch-flicker {
+  0%, 100% {
+    opacity: 1;
+  }
+  33% {
+    opacity: 0.9;
+  }
+  66% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 0.85;
+  }
+}
+
+@keyframes glitch-scanline {
+  0%, 100% {
+    background-position: 0 0;
+  }
+  50% {
+    background-position: 0 2px;
+  }
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .glitch-container:hover,
+  .glitch-container:hover::before,
+  .glitch-container:hover::after,
+  .glitch-container:hover .glitch-icon {
+    animation: none;
+  }
+
+  .glitch-container:hover::before,
+  .glitch-container:hover::after {
+    opacity: 0;
+  }
+}

--- a/components/page-layout.tsx
+++ b/components/page-layout.tsx
@@ -30,8 +30,8 @@ export function PageLayout({
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">
           <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
-            <div className="p-2 rounded-lg bg-primary/10 border border-primary/30">
-              <Terminal className="h-6 w-6 text-primary" />
+            <div className="glitch-container p-2 rounded-lg bg-primary/10 border border-primary/30">
+              <Terminal className="glitch-icon h-6 w-6 text-primary" />
             </div>
             <div>
               <h1 className="text-2xl font-bold text-foreground">Commit Explorer</h1>


### PR DESCRIPTION
## Summary
Adds a CSS-only cyberpunk glitch effect to the Terminal logo icon that activates on hover, fitting the existing dark theme of the app.

## Changes
- Added glitch CSS keyframes and styles to `globals.css`:
  - RGB color split using pseudo-elements with clip-path
  - Position jitter animation
  - Scanline overlay effect
  - Icon flicker effect
- Applied `glitch-container` and `glitch-icon` classes to the logo in `page-layout.tsx`
- Added `@media (prefers-reduced-motion: reduce)` support for accessibility

## Technical Details
- Pure CSS implementation (no JS overhead)
- Animation duration: ~300ms loop while hovered
- Effects combine: chromatic aberration, jitter, scanlines, and flicker
- No layout shift during animation (uses `transform` instead of position)

## Testing
- [x] Linting passed
- [x] Build successful
- [x] Verified glitch classes render in HTML
- [x] Accessibility: respects reduced-motion preference

Closes #14