### PR TITLE
Closes #9: Add keyboard navigation and command palette

### DIFF
--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useCallback } from "react"
+import { useRouter } from "next/navigation"
+import {
+  GitCommit,
+  GitCompare,
+  Rocket,
+  Settings,
+  Home,
+  Keyboard,
+} from "lucide-react"
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from "@/components/ui/command"
+
+interface CommandPaletteProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onShowHelp: () => void
+  onFocusSearch: () => void
+}
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  onShowHelp,
+  onFocusSearch,
+}: CommandPaletteProps) {
+  const router = useRouter()
+
+  const runCommand = useCallback(
+    (command: () => void) => {
+      onOpenChange(false)
+      command()
+    },
+    [onOpenChange]
+  )
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Navigation">
+          <CommandItem
+            onSelect={() => runCommand(() => router.push("/"))}
+          >
+            <Home className="mr-2 h-4 w-4" />
+            <span>Home</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() => runCommand(() => router.push("/settings"))}
+          >
+            <Settings className="mr-2 h-4 w-4" />
+            <span>Settings</span>
+          </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Search Modes">
+          <CommandItem
+            onSelect={() =>
+              runCommand(() => {
+                router.push("/")
+                setTimeout(onFocusSearch, 100)
+              })
+            }
+          >
+            <GitCommit className="mr-2 h-4 w-4" />
+            <span>Single Commit</span>
+            <CommandShortcut>/</CommandShortcut>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              runCommand(() => {
+                router.push("/")
+                setTimeout(onFocusSearch, 100)
+              })
+            }
+          >
+            <GitCompare className="mr-2 h-4 w-4" />
+            <span>Changelog</span>
+          </CommandItem>
+          <CommandItem
+            onSelect={() =>
+              runCommand(() => {
+                router.push("/")
+                setTimeout(onFocusSearch, 100)
+              })
+            }
+          >
+            <Rocket className="mr-2 h-4 w-4" />
+            <span>Deployment</span>
+          </CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Help">
+          <CommandItem onSelect={() => runCommand(onShowHelp)}>
+            <Keyboard className="mr-2 h-4 w-4" />
+            <span>Keyboard Shortcuts</span>
+            <CommandShortcut>?</CommandShortcut>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/components/keyboard-shortcuts-dialog.tsx
+++ b/components/keyboard-shortcuts-dialog.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface ShortcutItem {
+  keys: string[]
+  description: string
+}
+
+interface ShortcutGroup {
+  title: string
+  shortcuts: ShortcutItem[]
+}
+
+const shortcutGroups: ShortcutGroup[] = [
+  {
+    title: "Navigation",
+    shortcuts: [
+      { keys: ["/"], description: "Focus search input" },
+      { keys: ["Cmd", "K"], description: "Open command palette" },
+      { keys: ["Esc"], description: "Close dialogs / blur input" },
+    ],
+  },
+  {
+    title: "Results",
+    shortcuts: [
+      { keys: ["\u2191", "\u2193"], description: "Navigate through items" },
+      { keys: ["Enter"], description: "Select / open item" },
+    ],
+  },
+  {
+    title: "Help",
+    shortcuts: [{ keys: ["?"], description: "Show this dialog" }],
+  },
+]
+
+function KeyboardKey({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="inline-flex items-center justify-center h-6 min-w-[1.5rem] px-1.5 text-xs font-medium bg-secondary border border-border rounded shadow-sm">
+      {children}
+    </kbd>
+  )
+}
+
+export function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+}: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-background border-border sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-foreground">
+            Keyboard Shortcuts
+          </DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            Navigate faster with these keyboard shortcuts
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6 py-4">
+          {shortcutGroups.map((group) => (
+            <div key={group.title}>
+              <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
+                {group.title}
+              </h4>
+              <div className="space-y-2">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={shortcut.description}
+                    className="flex items-center justify-between text-sm"
+                  >
+                    <span className="text-foreground">
+                      {shortcut.description}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key, index) => (
+                        <span key={key} className="flex items-center gap-1">
+                          {index > 0 && (
+                            <span className="text-muted-foreground text-xs">
+                              +
+                            </span>
+                          )}
+                          <KeyboardKey>{key}</KeyboardKey>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="pt-2 border-t border-border">
+          <p className="text-xs text-muted-foreground text-center">
+            Press <KeyboardKey>Esc</KeyboardKey> to close
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/page-layout.tsx
+++ b/components/page-layout.tsx
@@ -1,11 +1,15 @@
 "use client"
 
 import type React from "react"
+import { useRef, useState, useCallback } from "react"
 import Link from "next/link"
 import { Terminal, Settings } from "lucide-react"
-import { CommitInput } from "@/components/commit-input"
+import { CommitInput, type CommitInputRef } from "@/components/commit-input"
 import { KonamiEffect } from "@/components/konami-effect"
+import { CommandPalette } from "@/components/command-palette"
+import { KeyboardShortcutsDialog } from "@/components/keyboard-shortcuts-dialog"
 import { useKonamiCode } from "@/hooks/use-konami-code"
+import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
 
 interface PageLayoutProps {
   children: React.ReactNode
@@ -29,11 +33,57 @@ export function PageLayout({
   // Easter egg: Konami code detection
   const { isActivated: konamiActivated, deactivate: deactivateKonami } = useKonamiCode()
 
+  // Keyboard navigation state
+  const [isCommandPaletteOpen, setIsCommandPaletteOpen] = useState(false)
+  const [isHelpOpen, setIsHelpOpen] = useState(false)
+  const commitInputRef = useRef<CommitInputRef>(null)
+
+  const handleFocusSearch = useCallback(() => {
+    commitInputRef.current?.focus()
+  }, [])
+
+  const handleOpenCommandPalette = useCallback(() => {
+    setIsCommandPaletteOpen(true)
+  }, [])
+
+  const handleShowHelp = useCallback(() => {
+    setIsHelpOpen(true)
+  }, [])
+
+  const handleEscape = useCallback(() => {
+    if (isCommandPaletteOpen) {
+      setIsCommandPaletteOpen(false)
+    } else if (isHelpOpen) {
+      setIsHelpOpen(false)
+    } else {
+      commitInputRef.current?.blur()
+    }
+  }, [isCommandPaletteOpen, isHelpOpen])
+
+  useKeyboardShortcuts({
+    onFocusSearch: handleFocusSearch,
+    onOpenCommandPalette: handleOpenCommandPalette,
+    onShowHelp: handleShowHelp,
+    onEscape: handleEscape,
+  })
+
   return (
-    <main className="min-h-screen bg-background">
+    <main className="min-h-screen bg-background flex flex-col">
       {/* Easter egg: Konami code effect */}
       <KonamiEffect isActive={konamiActivated} onComplete={deactivateKonami} />
-      <div className="max-w-2xl mx-auto px-4 py-12">
+
+      {/* Command Palette */}
+      <CommandPalette
+        open={isCommandPaletteOpen}
+        onOpenChange={setIsCommandPaletteOpen}
+        onShowHelp={handleShowHelp}
+        onFocusSearch={handleFocusSearch}
+      />
+
+      {/* Keyboard Shortcuts Help */}
+      <KeyboardShortcutsDialog open={isHelpOpen} onOpenChange={setIsHelpOpen} />
+
+      <div className="flex-1 max-w-2xl mx-auto px-4 py-12 w-full">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
           <Link href="/" className="flex items-center gap-3 hover:opacity-80 transition-opacity">
@@ -57,6 +107,7 @@ export function PageLayout({
         {/* Search Input */}
         <div className="mb-8">
           <CommitInput
+            ref={commitInputRef}
             isLoading={isLoading}
             initialMode={initialMode}
             initialSha={initialSha}
@@ -69,6 +120,44 @@ export function PageLayout({
         {/* Content */}
         {children}
       </div>
+
+      {/* Footer with keyboard hints */}
+      <footer className="border-t border-border py-3 px-4">
+        <div className="max-w-2xl mx-auto flex items-center justify-center gap-4 text-xs text-muted-foreground">
+          <button
+            type="button"
+            onClick={handleFocusSearch}
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            <kbd className="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1 text-[10px] bg-secondary border border-border rounded">
+              /
+            </kbd>
+            <span>search</span>
+          </button>
+          <span className="text-border">|</span>
+          <button
+            type="button"
+            onClick={handleOpenCommandPalette}
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            <kbd className="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1 text-[10px] bg-secondary border border-border rounded">
+              ⌘K
+            </kbd>
+            <span>palette</span>
+          </button>
+          <span className="text-border">|</span>
+          <button
+            type="button"
+            onClick={handleShowHelp}
+            className="flex items-center gap-1.5 hover:text-foreground transition-colors"
+          >
+            <kbd className="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1 text-[10px] bg-secondary border border-border rounded">
+              ?
+            </kbd>
+            <span>shortcuts</span>
+          </button>
+        </div>
+      </footer>
     </main>
   )
 }

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,0 +1,162 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  children,
+  ...props
+}: React.ComponentProps<typeof Dialog>) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0" showCloseButton={false}>
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      className="flex items-center border-b border-border px-3"
+      data-slot="command-input-wrapper"
+    >
+      <SearchIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] overflow-y-auto overflow-x-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("bg-border -mx-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -2,20 +2,24 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-  return (
-    <input
-      type={type}
-      data-slot="input"
-      className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
-        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
-        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
-        className,
-      )}
-      {...props}
-    />
-  )
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        ref={ref}
+        data-slot="input"
+        className={cn(
+          'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+          'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+          className,
+        )}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'
 
 export { Input }

--- a/hooks/use-keyboard-shortcuts.ts
+++ b/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,71 @@
+"use client"
+
+import { useEffect, useCallback } from "react"
+
+interface KeyboardShortcutHandlers {
+  onFocusSearch?: () => void
+  onOpenCommandPalette?: () => void
+  onShowHelp?: () => void
+  onEscape?: () => void
+}
+
+function isInputElement(target: EventTarget | null): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  )
+}
+
+export function useKeyboardShortcuts({
+  onFocusSearch,
+  onOpenCommandPalette,
+  onShowHelp,
+  onEscape,
+}: KeyboardShortcutHandlers) {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const isInInput = isInputElement(event.target)
+
+      // Cmd/Ctrl+K: Open command palette (works anywhere)
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+        event.preventDefault()
+        onOpenCommandPalette?.()
+        return
+      }
+
+      // Escape: Close/clear current view
+      if (event.key === "Escape") {
+        onEscape?.()
+        return
+      }
+
+      // Don't handle these shortcuts when in input fields
+      if (isInInput) {
+        return
+      }
+
+      // /: Focus search input
+      if (event.key === "/") {
+        event.preventDefault()
+        onFocusSearch?.()
+        return
+      }
+
+      // ?: Show keyboard shortcuts help
+      if (event.key === "?" || (event.shiftKey && event.key === "/")) {
+        event.preventDefault()
+        onShowHelp?.()
+        return
+      }
+    },
+    [onFocusSearch, onOpenCommandPalette, onShowHelp, onEscape]
+  )
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [handleKeyDown])
+}


### PR DESCRIPTION
## Summary
Adds keyboard navigation for power users to navigate the tool efficiently. Users can now use keyboard shortcuts to quickly search, access commands, and get help without using their mouse.

## Changes
- **Keyboard shortcuts hook** (`hooks/use-keyboard-shortcuts.ts`): Centralizes keyboard event handling
- **Command palette** (`components/command-palette.tsx`): Opens with `Cmd+K`, provides quick navigation and mode switching using cmdk
- **Help dialog** (`components/keyboard-shortcuts-dialog.tsx`): Shows all available shortcuts when pressing `?`
- **Footer hints**: Clickable keyboard shortcut hints at the bottom of the page
- **Input ref support**: Updated `CommitInput` and `Input` components to support focus via refs

## Keyboard Shortcuts
| Key | Action |
|-----|--------|
| `/` | Focus search input |
| `⌘K` / `Ctrl+K` | Open command palette |
| `?` | Show keyboard shortcuts help |
| `Esc` | Close dialogs / blur input |
| Arrow keys | Navigate within command palette |
| `Enter` | Select item in command palette |

## Testing
- [x] Lint passed
- [x] Build successful
- [x] Manual testing: all shortcuts work as expected
- [x] Command palette navigation with arrow keys works

Closes #9