### PR TITLE
Closes #23: Fix hover state text legibility in dark mode

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,11 +13,11 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 dark:hover:text-foreground',
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 dark:hover:text-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -125,7 +125,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground dark:data-[selected=true]:text-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
         className
       )}
       {...props}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -107,7 +107,7 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        "focus:bg-accent focus:text-accent-foreground dark:focus:text-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
Fixed hover and focus states making text illegible (black text on dark background) in the cyberpunk dark theme.

## Changes
- **button.tsx**: Added `dark:hover:text-foreground` to outline and ghost variants to maintain readable text on semi-transparent hover backgrounds
- **select.tsx**: Added `dark:focus:text-foreground` to SelectItem for readable text in dropdown focus states
- **command.tsx**: Added `dark:data-[selected=true]:text-foreground` to CommandItem for readable text in command palette selection

## Root Cause
The `--accent-foreground` CSS variable is `oklch(0.1 0.015 260)` (nearly black), designed for text on solid cyan backgrounds. However, in dark mode, hover/focus states use semi-transparent backgrounds (`bg-accent/50`, `bg-input/50`), leaving black text invisible against the dark theme.

## Testing
- [x] Linting passed
- [x] Build successful
- [x] Manual verification: hover over mode toggle buttons, navigate select dropdowns, use command palette (Ctrl/Cmd+K)

Closes #23