### PR TITLE
feat: Show recent deployments list for quick selection

### DIFF
--- a/app/api/mach-config/recent/route.ts
+++ b/app/api/mach-config/recent/route.ts
@@ -1,0 +1,92 @@
+import { type NextRequest, NextResponse } from "next/server"
+import type { RecentDeployment } from "@/lib/types"
+
+const GITHUB_API = "https://api.github.com"
+
+function getHeaders() {
+  const headers: HeadersInit = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  }
+
+  if (process.env.GITHUB_TOKEN) {
+    headers["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+
+  return headers
+}
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const repo = searchParams.get("repo")
+
+  if (!repo) {
+    return NextResponse.json({ error: "Missing required parameter: repo" }, { status: 400 })
+  }
+
+  const [owner, repoName] = repo.split("/")
+
+  if (!owner || !repoName) {
+    return NextResponse.json({ error: "Invalid repo format. Use owner/repo" }, { status: 400 })
+  }
+
+  try {
+    // Fetch recent commits that modified mach-config/ directory
+    const response = await fetch(
+      `${GITHUB_API}/repos/${owner}/${repoName}/commits?path=mach-config&per_page=30`,
+      { headers: getHeaders() }
+    )
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}))
+      throw new Error(error.message || `Failed to fetch commits: ${response.status}`)
+    }
+
+    const commits = await response.json()
+
+    // Filter to only commits that touch *-versions.yaml files and dedupe
+    const deploymentsMap = new Map<string, RecentDeployment>()
+
+    for (const commit of commits) {
+      if (deploymentsMap.size >= 10) break
+
+      // Fetch the commit details to get files
+      const detailResponse = await fetch(
+        `${GITHUB_API}/repos/${owner}/${repoName}/commits/${commit.sha}`,
+        { headers: getHeaders() }
+      )
+
+      if (!detailResponse.ok) continue
+
+      const detail = await detailResponse.json()
+      const versionFiles = (detail.files || []).filter(
+        (f: { filename: string }) =>
+          f.filename.startsWith("mach-config/") && f.filename.endsWith("-versions.yaml")
+      )
+
+      if (versionFiles.length === 0) continue
+
+      // Extract environment names from version file names
+      const environments = versionFiles.map((f: { filename: string }) => {
+        const match = f.filename.match(/mach-config\/([^/]+)-versions\.yaml$/)
+        return match ? match[1] : "unknown"
+      })
+
+      deploymentsMap.set(commit.sha, {
+        sha: commit.sha,
+        shortSha: commit.sha.substring(0, 7),
+        message: commit.commit.message.split("\n")[0],
+        author: commit.author?.login || commit.commit.author.name,
+        date: commit.commit.author.date,
+        environments: [...new Set(environments)],
+      })
+    }
+
+    const deployments = Array.from(deploymentsMap.values())
+
+    return NextResponse.json({ deployments })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to fetch recent deployments"
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/components/commit-input.tsx
+++ b/components/commit-input.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Search, Settings, Plus, Trash2, GitCompare, GitCommit, Rocket } from "lucide-react"
+import { RecentDeployments } from "./recent-deployments"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import {
   Dialog,
@@ -411,23 +412,26 @@ export const CommitInput = forwardRef<CommitInputRef, CommitInputProps>(function
             </Button>
           </div>
         ) : (
-          <div className="flex gap-3">
-            <Input
-              ref={deploymentShaInputRef}
-              type="text"
-              placeholder="Mach-config commit SHA..."
-              value={deploymentSha}
-              onChange={(e) => setDeploymentSha(e.target.value)}
-              className="flex-1 bg-secondary border-border font-mono text-sm placeholder:text-muted-foreground focus:border-cyan focus:ring-cyan"
-            />
-            <Button
-              type="submit"
-              disabled={isLoading || !isValid}
-              className="bg-primary text-primary-foreground hover:bg-primary/90 gap-2"
-            >
-              <Rocket className="h-4 w-4" />
-              {isLoading ? "Analyzing..." : "Analyze"}
-            </Button>
+          <div className="flex flex-col gap-3">
+            <div className="flex gap-3">
+              <Input
+                ref={deploymentShaInputRef}
+                type="text"
+                placeholder="Mach-config commit SHA..."
+                value={deploymentSha}
+                onChange={(e) => setDeploymentSha(e.target.value)}
+                className="flex-1 bg-secondary border-border font-mono text-sm placeholder:text-muted-foreground focus:border-cyan focus:ring-cyan"
+              />
+              <Button
+                type="submit"
+                disabled={isLoading || !isValid}
+                className="bg-primary text-primary-foreground hover:bg-primary/90 gap-2"
+              >
+                <Rocket className="h-4 w-4" />
+                {isLoading ? "Analyzing..." : "Analyze"}
+              </Button>
+            </div>
+            <RecentDeployments repo={repo} />
           </div>
         )}
       </div>

--- a/components/recent-deployments.tsx
+++ b/components/recent-deployments.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import useSWR from "swr"
+import { useRouter } from "next/navigation"
+import { formatDistanceToNow } from "date-fns"
+import { Rocket, User, Clock, AlertCircle, Loader2 } from "lucide-react"
+import type { RecentDeployment } from "@/lib/types"
+import { AuthorHover } from "./author-hover"
+
+interface RecentDeploymentsProps {
+  repo: string
+}
+
+interface ApiResponse {
+  deployments: RecentDeployment[]
+  error?: string
+}
+
+const fetcher = async (url: string): Promise<ApiResponse> => {
+  const res = await fetch(url)
+  if (!res.ok) {
+    const error = await res.json()
+    throw new Error(error.error || "Failed to fetch recent deployments")
+  }
+  return res.json()
+}
+
+export function RecentDeployments({ repo }: RecentDeploymentsProps) {
+  const router = useRouter()
+  const { data, error, isLoading } = useSWR<ApiResponse>(
+    repo ? `/api/mach-config/recent?repo=${encodeURIComponent(repo)}` : null,
+    fetcher,
+    { revalidateOnFocus: false, dedupingInterval: 60000 }
+  )
+
+  const handleClick = (sha: string) => {
+    router.push(`/deployment/${sha}?repo=${encodeURIComponent(repo)}`)
+  }
+
+  if (isLoading) {
+    return (
+      <div className="mt-4 p-4 rounded-lg border border-border bg-secondary/30">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Loading recent deployments...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mt-4 p-4 rounded-lg border border-error/30 bg-error/10">
+        <div className="flex items-center gap-2 text-sm text-error">
+          <AlertCircle className="h-4 w-4" />
+          <span>Failed to load recent deployments</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (!data?.deployments?.length) {
+    return (
+      <div className="mt-4 p-4 rounded-lg border border-border bg-secondary/30">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Rocket className="h-4 w-4" />
+          <span>No recent mach-config deployments found</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Rocket className="h-4 w-4 text-primary" />
+        <span className="text-sm font-medium text-foreground">Recent Deployments</span>
+        <span className="text-xs text-muted-foreground">({data.deployments.length})</span>
+      </div>
+      <div className="space-y-2">
+        {data.deployments.map((deployment) => (
+          <button
+            key={deployment.sha}
+            type="button"
+            onClick={() => handleClick(deployment.sha)}
+            className="w-full text-left p-3 rounded-lg border border-border bg-secondary/30 hover:bg-secondary/60 hover:border-primary/50 transition-all duration-200 group"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="font-mono text-sm text-primary group-hover:text-cyan transition-colors">
+                    {deployment.shortSha}
+                  </span>
+                  <div className="flex gap-1 flex-wrap">
+                    {deployment.environments.map((env) => (
+                      <span
+                        key={env}
+                        className="text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary border border-primary/30 uppercase tracking-wider"
+                      >
+                        {env}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <p className="text-sm text-foreground truncate" title={deployment.message}>
+                  {deployment.message}
+                </p>
+                <div className="flex items-center gap-3 mt-1.5 text-xs text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <User className="h-3 w-3" />
+                    <AuthorHover username={deployment.author}>{deployment.author}</AuthorHover>
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {formatDistanceToNow(new Date(deployment.date), { addSuffix: true })}
+                  </span>
+                </div>
+              </div>
+              <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                <span className="text-xs text-primary">View &rarr;</span>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -139,3 +139,12 @@ export interface IntegrationCredentials {
     apiKey: string
   }
 }
+
+export interface RecentDeployment {
+  sha: string
+  shortSha: string
+  message: string
+  author: string
+  date: string
+  environments: string[]
+}


### PR DESCRIPTION
## Summary
- Added a clickable list of recent mach-config deployments in deployment mode
- Users can now quickly select from the last 10 deployments instead of manually entering commit SHAs
- Each deployment shows short SHA, commit message, author, relative time, and environment badges

## Changes
- **New API endpoint** `GET /api/mach-config/recent`: Fetches last 10 commits that modified `mach-config/*-versions.yaml` files
- **New component** `RecentDeployments`: Displays clickable list with loading/error/empty states
- **Updated** `commit-input.tsx`: Shows recent deployments below input when in deployment mode
- **New type** `RecentDeployment` in `lib/types.ts`

## Screenshots

The component displays a styled list with:
- Short SHA in cyan/primary color
- Environment badges (e.g., `prd-prem`, `acc-prem`)
- Commit message truncated if long
- Author with hover effect
- Relative time (e.g., "2 hours ago")
- "View →" indicator on hover

## Testing
- [x] Lint passes
- [x] Build successful
- [x] API endpoint correctly filters for version files
- [x] Error handling works when repo is inaccessible
- [x] Loading state displays properly
- [x] List auto-refreshes on repository change (SWR)

Closes #40