### PR TITLE
Closes #6: Honeycomb Integration - Query Correlation

### DIFF
--- a/app/api/honeycomb/route.ts
+++ b/app/api/honeycomb/route.ts
@@ -1,0 +1,74 @@
+import { type NextRequest, NextResponse } from "next/server"
+import {
+  generateDeploymentQueries,
+  generateComponentQueries,
+  getHoneycombConfigFromEnv,
+  isHoneycombConfigured,
+  isHoneycombEU,
+} from "@/lib/honeycomb"
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const deploymentDate = searchParams.get("deploymentDate")
+  const componentName = searchParams.get("componentName")
+  const windowHours = searchParams.get("windowHours")
+
+  if (!deploymentDate) {
+    return NextResponse.json(
+      { error: "Missing required parameter: deploymentDate" },
+      { status: 400 }
+    )
+  }
+
+  // Check if Honeycomb is configured
+  if (!isHoneycombConfigured()) {
+    return NextResponse.json(
+      {
+        error: "Honeycomb is not configured",
+        configured: false,
+        queries: [],
+      },
+      { status: 200 }
+    )
+  }
+
+  const config = getHoneycombConfigFromEnv()
+
+  if (!config) {
+    return NextResponse.json(
+      {
+        error: "Honeycomb team and dataset must be configured via HONEYCOMB_TEAM and HONEYCOMB_DATASET",
+        configured: false,
+        queries: [],
+      },
+      { status: 200 }
+    )
+  }
+
+  const isEU = isHoneycombEU()
+  const hours = windowHours ? parseInt(windowHours, 10) : 1
+
+  let queries
+  if (componentName) {
+    queries = generateComponentQueries(config, componentName, deploymentDate, {
+      windowHours: hours,
+      isEU,
+    })
+  } else {
+    queries = generateDeploymentQueries(config, deploymentDate, {
+      windowHours: hours,
+      isEU,
+    })
+  }
+
+  return NextResponse.json({
+    configured: true,
+    queries,
+    config: {
+      team: config.team,
+      dataset: config.dataset,
+      environment: config.environment,
+      isEU,
+    },
+  })
+}

--- a/components/honeycomb-queries.tsx
+++ b/components/honeycomb-queries.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import type { HoneycombQueryUrl } from "@/lib/types"
+import { ContextCard } from "./context-card"
+import { Button } from "@/components/ui/button"
+import {
+  Search,
+  AlertTriangle,
+  Activity,
+  Gauge,
+  ExternalLink,
+  Waves,
+} from "lucide-react"
+
+interface HoneycombQueriesProps {
+  queries: HoneycombQueryUrl[]
+  componentName?: string
+  deploymentTime?: string
+}
+
+const QUERY_ICONS: Record<string, React.ReactNode> = {
+  errors: <AlertTriangle className="h-4 w-4" />,
+  latency: <Activity className="h-4 w-4" />,
+  throughput: <Gauge className="h-4 w-4" />,
+  traces: <Waves className="h-4 w-4" />,
+}
+
+const QUERY_COLORS: Record<string, string> = {
+  errors: "text-red-400 hover:text-red-300 border-red-500/30 hover:border-red-500/50 hover:bg-red-500/10",
+  latency: "text-yellow-400 hover:text-yellow-300 border-yellow-500/30 hover:border-yellow-500/50 hover:bg-yellow-500/10",
+  throughput: "text-blue-400 hover:text-blue-300 border-blue-500/30 hover:border-blue-500/50 hover:bg-blue-500/10",
+  traces: "text-purple-400 hover:text-purple-300 border-purple-500/30 hover:border-purple-500/50 hover:bg-purple-500/10",
+}
+
+export function HoneycombQueries({ queries, componentName, deploymentTime }: HoneycombQueriesProps) {
+  if (queries.length === 0) {
+    return null
+  }
+
+  return (
+    <ContextCard
+      title="Honeycomb Queries"
+      icon={<Search className="h-4 w-4" />}
+    >
+      <div className="space-y-3">
+        {componentName && (
+          <p className="text-xs text-muted-foreground">
+            Observability queries for <span className="font-medium text-foreground">{componentName}</span>
+            {deploymentTime && (
+              <span> starting from deployment time</span>
+            )}
+          </p>
+        )}
+
+        <div className="grid gap-2">
+          {queries.map((query) => (
+            <a
+              key={query.type}
+              href={query.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block"
+            >
+              <Button
+                variant="outline"
+                className={`w-full justify-between h-auto py-2.5 px-3 ${QUERY_COLORS[query.type] || ""}`}
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex-shrink-0">
+                    {QUERY_ICONS[query.type] || <Search className="h-4 w-4" />}
+                  </div>
+                  <div className="text-left">
+                    <div className="text-sm font-medium">{query.label}</div>
+                    <div className="text-xs opacity-70">{query.description}</div>
+                  </div>
+                </div>
+                <ExternalLink className="h-3.5 w-3.5 flex-shrink-0 opacity-50" />
+              </Button>
+            </a>
+          ))}
+        </div>
+
+        <p className="text-xs text-muted-foreground/70 pt-1">
+          Queries are pre-filtered to 1 hour post-deployment window
+        </p>
+      </div>
+    </ContextCard>
+  )
+}
+
+interface HoneycombQueriesCompactProps {
+  queries: HoneycombQueryUrl[]
+}
+
+export function HoneycombQueriesCompact({ queries }: HoneycombQueriesCompactProps) {
+  if (queries.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {queries.map((query) => (
+        <a
+          key={query.type}
+          href={query.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={query.description}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            className={`h-7 px-2.5 text-xs gap-1.5 ${QUERY_COLORS[query.type] || ""}`}
+          >
+            {QUERY_ICONS[query.type] || <Search className="h-3 w-3" />}
+            <span>{query.label.replace("View ", "")}</span>
+            <ExternalLink className="h-2.5 w-2.5 opacity-50" />
+          </Button>
+        </a>
+      ))}
+    </div>
+  )
+}

--- a/lib/honeycomb.ts
+++ b/lib/honeycomb.ts
@@ -1,0 +1,261 @@
+import type {
+  HoneycombQueryUrl,
+  HoneycombQueryType,
+  HoneycombConfig,
+  HoneycombFilter,
+  HoneycombCalculation,
+} from "./types"
+
+// Default Honeycomb UI base URLs
+const HONEYCOMB_UI_US = "https://ui.honeycomb.io"
+const HONEYCOMB_UI_EU = "https://ui.eu1.honeycomb.io"
+
+// Query templates for different observability concerns
+const QUERY_TEMPLATES: Record<
+  HoneycombQueryType,
+  {
+    label: string
+    description: string
+    calculations: HoneycombCalculation[]
+    breakdowns?: string[]
+    filters?: HoneycombFilter[]
+  }
+> = {
+  errors: {
+    label: "View Errors",
+    description: "Error rate and failed requests post-deployment",
+    calculations: [
+      { op: "COUNT" },
+      { op: "COUNT" }, // Will be filtered for errors
+    ],
+    breakdowns: ["error", "http.status_code", "service.name"],
+    filters: [
+      { column: "error", op: "=", value: true },
+    ],
+  },
+  latency: {
+    label: "View Latency",
+    description: "P50/P95 latency breakdown",
+    calculations: [
+      { op: "HEATMAP", column: "duration_ms" },
+      { op: "P50", column: "duration_ms" },
+      { op: "P95", column: "duration_ms" },
+      { op: "P99", column: "duration_ms" },
+    ],
+    breakdowns: ["name", "service.name"],
+  },
+  throughput: {
+    label: "View Throughput",
+    description: "Request volume and rate",
+    calculations: [
+      { op: "COUNT" },
+      { op: "AVG", column: "duration_ms" },
+    ],
+    breakdowns: ["name", "http.method", "service.name"],
+  },
+  traces: {
+    label: "View Traces",
+    description: "Sample traces for investigation",
+    calculations: [{ op: "COUNT" }],
+    breakdowns: ["trace.trace_id", "name"],
+  },
+}
+
+interface QuerySpec {
+  time_range?: number // seconds
+  start_time?: number // unix timestamp
+  end_time?: number // unix timestamp
+  granularity?: number
+  breakdowns?: string[]
+  calculations?: Array<{ op: string; column?: string }>
+  filters?: Array<{ column: string; op: string; value: string | number | boolean }>
+  filter_combination?: "AND" | "OR"
+  orders?: Array<{ column?: string; op?: string; order: "ascending" | "descending" }>
+  limit?: number
+}
+
+/**
+ * Builds a Honeycomb query URL with the specified parameters
+ */
+export function buildHoneycombQueryUrl(
+  config: HoneycombConfig,
+  querySpec: QuerySpec,
+  isEU = false
+): string {
+  const baseUrl = isEU ? HONEYCOMB_UI_EU : HONEYCOMB_UI_US
+  const encodedQuery = encodeURIComponent(JSON.stringify(querySpec))
+
+  // Build the URL path based on whether we have an environment
+  let path: string
+  if (config.environment) {
+    path = `${config.team}/environments/${config.environment}/datasets/${config.dataset}`
+  } else {
+    path = `${config.team}/datasets/${config.dataset}`
+  }
+
+  return `${baseUrl}/${path}?query=${encodedQuery}`
+}
+
+/**
+ * Generates Honeycomb query URLs for a deployment time window
+ */
+export function generateDeploymentQueries(
+  config: HoneycombConfig,
+  deploymentDate: string,
+  options: {
+    windowHours?: number
+    isEU?: boolean
+    serviceFilter?: string
+  } = {}
+): HoneycombQueryUrl[] {
+  const { windowHours = 1, isEU = false, serviceFilter } = options
+
+  // Calculate time window: deployment time to N hours after
+  const deploymentTime = new Date(deploymentDate)
+  const startTime = Math.floor(deploymentTime.getTime() / 1000)
+  const endTime = Math.floor(startTime + windowHours * 60 * 60)
+
+  const queries: HoneycombQueryUrl[] = []
+
+  for (const [type, template] of Object.entries(QUERY_TEMPLATES)) {
+    const queryType = type as HoneycombQueryType
+
+    // Build the query spec
+    const querySpec: QuerySpec = {
+      start_time: startTime,
+      end_time: endTime,
+      granularity: 60, // 1 minute buckets
+      calculations: template.calculations.map((calc) => ({
+        op: calc.op,
+        ...(calc.column && { column: calc.column }),
+      })),
+      breakdowns: template.breakdowns,
+      filter_combination: "AND",
+      filters: [],
+      limit: 1000,
+    }
+
+    // Add template-specific filters
+    if (template.filters) {
+      querySpec.filters = template.filters.map((f) => ({
+        column: f.column,
+        op: f.op,
+        value: f.value,
+      }))
+    }
+
+    // Add service filter if specified
+    if (serviceFilter) {
+      querySpec.filters = querySpec.filters || []
+      querySpec.filters.push({
+        column: "service.name",
+        op: "=",
+        value: serviceFilter,
+      })
+    }
+
+    // Add ordering for traces to get recent ones
+    if (queryType === "traces") {
+      querySpec.orders = [{ order: "descending" }]
+      querySpec.limit = 100
+    }
+
+    const url = buildHoneycombQueryUrl(config, querySpec, isEU)
+
+    queries.push({
+      type: queryType,
+      label: template.label,
+      description: template.description,
+      url,
+    })
+  }
+
+  return queries
+}
+
+/**
+ * Generates a direct trace link for a specific trace ID
+ */
+export function buildTraceUrl(
+  config: HoneycombConfig,
+  traceId: string,
+  isEU = false
+): string {
+  const baseUrl = isEU ? HONEYCOMB_UI_EU : HONEYCOMB_UI_US
+
+  let path: string
+  if (config.environment) {
+    path = `${config.team}/environments/${config.environment}/datasets/${config.dataset}/trace`
+  } else {
+    path = `${config.team}/datasets/${config.dataset}/trace`
+  }
+
+  return `${baseUrl}/${path}?trace_id=${encodeURIComponent(traceId)}`
+}
+
+/**
+ * Gets the default Honeycomb configuration from environment variables
+ * This should be called server-side only
+ */
+export function getHoneycombConfigFromEnv(): HoneycombConfig | null {
+  const team = process.env.HONEYCOMB_TEAM
+  const dataset = process.env.HONEYCOMB_DATASET
+
+  if (!team || !dataset) {
+    return null
+  }
+
+  return {
+    team,
+    dataset,
+    environment: process.env.HONEYCOMB_ENVIRONMENT,
+    apiEndpoint: process.env.HONEYCOMB_API_ENDPOINT,
+  }
+}
+
+/**
+ * Checks if Honeycomb is configured (has API key)
+ */
+export function isHoneycombConfigured(): boolean {
+  return Boolean(process.env.HONEYCOMB_API_KEY)
+}
+
+/**
+ * Determines if the Honeycomb instance is EU based on API endpoint
+ */
+export function isHoneycombEU(): boolean {
+  const endpoint = process.env.HONEYCOMB_API_ENDPOINT
+  return endpoint?.includes("eu1") ?? false
+}
+
+/**
+ * Maps a component name to a potential service name in Honeycomb
+ * This is a heuristic mapping that may need customization per project
+ */
+export function mapComponentToService(componentName: string): string {
+  // Common patterns:
+  // - checkout-widget -> checkout-widget
+  // - fx-search -> fx-search
+  // - header-component -> header-component
+  return componentName.toLowerCase().replace(/_/g, "-")
+}
+
+/**
+ * Generates queries scoped to a specific deployed component
+ */
+export function generateComponentQueries(
+  config: HoneycombConfig,
+  componentName: string,
+  deploymentDate: string,
+  options: {
+    windowHours?: number
+    isEU?: boolean
+  } = {}
+): HoneycombQueryUrl[] {
+  const serviceName = mapComponentToService(componentName)
+
+  return generateDeploymentQueries(config, deploymentDate, {
+    ...options,
+    serviceFilter: serviceName,
+  })
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -103,6 +103,52 @@ export interface MachConfigDeployment {
   components: ComponentVersionChange[]
 }
 
+// Honeycomb types
+export type HoneycombQueryType = "errors" | "latency" | "throughput" | "traces"
+
+export interface HoneycombQueryConfig {
+  type: HoneycombQueryType
+  label: string
+  description: string
+  icon: string
+}
+
+export interface HoneycombQueryParams {
+  dataset: string
+  team: string
+  environment?: string
+  startTime: string // ISO timestamp
+  endTime: string // ISO timestamp
+  filters?: HoneycombFilter[]
+  breakdowns?: string[]
+  calculations?: HoneycombCalculation[]
+}
+
+export interface HoneycombFilter {
+  column: string
+  op: "=" | "!=" | ">" | "<" | "contains" | "starts-with" | "exists"
+  value: string | number | boolean
+}
+
+export interface HoneycombCalculation {
+  op: "COUNT" | "AVG" | "P50" | "P95" | "P99" | "MAX" | "MIN" | "SUM" | "HEATMAP"
+  column?: string
+}
+
+export interface HoneycombQueryUrl {
+  type: HoneycombQueryType
+  label: string
+  description: string
+  url: string
+}
+
+export interface HoneycombConfig {
+  team: string
+  dataset: string
+  environment?: string
+  apiEndpoint?: string // defaults to US, set to https://api.eu1.honeycomb.io for EU
+}
+
 // Settings & Integration types
 export type IntegrationStatus = "connected" | "not_configured" | "error"
 


### PR DESCRIPTION
## Summary

Implements Phase 4 of the roadmap - Honeycomb integration for deployment observability. This feature generates Honeycomb query URLs pre-filtered to deployment time windows, allowing on-call engineers to quickly investigate issues related to specific deployments.

- **Query URL Generation**: Generate Honeycomb query URLs for errors, latency, throughput, and traces
- **Time Window Filtering**: Queries are pre-filtered to 1-hour post-deployment window
- **Component Scoping**: Support component-specific queries for detailed investigation
- **EU Support**: Works with both US and EU Honeycomb instances
- **Quick Actions UI**: Color-coded buttons with icons for each query type

## Changes

- Added `lib/honeycomb.ts` with query URL generation functions
- Created `components/honeycomb-queries.tsx` for UI display
- Added `/api/honeycomb` endpoint for server-side configuration
- Integrated Honeycomb queries into deployment display
- Updated types and documentation

## Configuration

New environment variables:
```bash
HONEYCOMB_API_KEY=      # Required for integration
HONEYCOMB_TEAM=         # Team slug
HONEYCOMB_DATASET=      # Default dataset
HONEYCOMB_ENVIRONMENT=  # Optional environment
HONEYCOMB_API_ENDPOINT= # Optional: EU endpoint
```

## Test Plan

- [ ] Verify lint passes (`pnpm lint`)
- [ ] Verify build passes (`pnpm build`)
- [ ] Test with Honeycomb configured - queries should appear in deployment view
- [ ] Test without Honeycomb configured - queries section should not appear
- [ ] Verify query URLs open correct Honeycomb views

Closes #6