### PR TITLE
feat: increase recent deployments limit

### DIFF
--- a/app/api/mach-config/recent/route.ts
+++ b/app/api/mach-config/recent/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
   try {
     // Fetch recent commits that modified mach-config/ directory
     const response = await fetch(
-      `${GITHUB_API}/repos/${owner}/${repoName}/commits?path=mach-config&per_page=30`,
+      `${GITHUB_API}/repos/${owner}/${repoName}/commits?path=mach-config&per_page=100`,
       { headers: getHeaders() }
     )
 
@@ -49,7 +49,7 @@ export async function GET(request: NextRequest) {
     const deploymentsMap = new Map<string, RecentDeployment>()
 
     for (const commit of commits) {
-      if (deploymentsMap.size >= 10) break
+      if (deploymentsMap.size >= 20) break
 
       // Fetch the commit details to get files
       const detailResponse = await fetch(


### PR DESCRIPTION
## Summary
- Increased GitHub API `per_page` from 30 to 100 to search through more commits
- Raised max deployments shown from 10 to 20

This addresses the issue where only 2 deployments were showing because the previous 30-commit search wasn't finding enough commits matching the `-versions.yaml` filter.

## Test plan
- [ ] Verify recent deployments section shows more entries
- [ ] Confirm no performance regression from larger API response